### PR TITLE
fix(scripts/atc): create-pr の jq で parse 失敗している

### DIFF
--- a/scripts/atc
+++ b/scripts/atc
@@ -145,8 +145,8 @@ case "$subcommand" in
     json="$contests_dir/$contest_name/contest.acc.json"
 
     gh pr create \
-      --title "$(jq '.contest.id' "$json"): $(jq '.contest.title' "$json")" \
-      --body "$(jq 'contest.url' "$json")" \
+      --title "$(jq -r '.contest.id' "$json"): $(jq -r '.contest.title' "$json")" \
+      --body "$(jq -r '.contest.url' "$json")" \
       --base master \
       --head "$contest_name"
     ;;


### PR DESCRIPTION
```console
❯ scripts/atc create-pr abc323
jq: error: contest/0 is not defined at <top-level>, line 1:
contest.url
jq: 1 compile error
Warning: 1 uncommitted change

Creating pull request for abc323 into master in fohte/atcoder

pull request create failed: GraphQL: Head sha can't be blank, Base sha can't be blank, No commits between master and abc323, Head ref must be a branch (createPullRequest)
```