### PR TITLE
lint: AtCoder やる上で邪魔になる RuboCop の警告を抑制する

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,11 +1,11 @@
-Metrics/MethodLength:
-  Enabled: false
-
-Metrics/PerceivedComplexity:
-  Enabled: false
-
-Metrics/CyclomaticComplexity:
+Metrics:
   Enabled: false
 
 Naming/MethodParameterName:
+  Enabled: false
+
+Lint:
+  AutoCorrect: false
+
+Style/FrozenStringLiteralComment:
   Enabled: false


### PR DESCRIPTION
競プロをやる上でも RuboCop の fixer は便利だが、linter としてはやや過剰なことが多い。

特に引数の名前を変えられたりするのは不便であることが多い。
競プロは綺麗なコードを書くことにそこまで手間をかける必要はないので、それを阻害するような設定は無効化する。